### PR TITLE
Add fields: published, unlisted, author

### DIFF
--- a/pages/posts/index.tsx
+++ b/pages/posts/index.tsx
@@ -5,7 +5,7 @@ import PageLayout from '../../components/PageLayout'
 import collectTags from '../../util/collectTags'
 import loadAllPosts from '../../util/loadAllPosts'
 
-interface LinkEntry {
+export interface LinkEntry {
     title: string
     url: string
 }
@@ -17,7 +17,7 @@ export const getStaticProps: GetStaticProps<Props> = async context => {
     const posts = await loadAllPosts()
     const postLinks = posts.map(post => ({
         title: post.frontMatter.title,
-        url: `/posts/${post.filename}`,
+        url: `/posts/${post.slug}`,
     }))
     const tags = collectTags(posts)
     const tagLinks = tags.map(tag => ({

--- a/pages/tags/[tag].tsx
+++ b/pages/tags/[tag].tsx
@@ -5,11 +5,11 @@ import PageLayout from '../../components/PageLayout'
 import collectTags from '../../util/collectTags'
 import getQueryParam from '../../util/getQueryParam'
 import loadAllPosts from '../../util/loadAllPosts'
-import { MarkdownFile } from '../../util/loadMarkdownFile'
+import { LinkEntry } from '../posts'
 
 interface Props {
     tag: string
-    posts: MarkdownFile[]
+    links: LinkEntry[]
 }
 
 export const getStaticPaths: GetStaticPaths = async () => {
@@ -22,10 +22,14 @@ export const getStaticProps: GetStaticProps<Props> = async context => {
     const tag = getQueryParam(context.params, 'tag').toLowerCase()
     const posts = await loadAllPosts()
     const filteredPosts = posts.filter(post => post.frontMatter.tags.includes(tag))
+    const links = filteredPosts.map(post => ({
+        title: post.frontMatter.title,
+        url: `/posts/${post.slug}`,
+    }))
     return {
         props: {
             tag,
-            posts: filteredPosts,
+            links,
         },
     }
 }
@@ -37,10 +41,10 @@ export default function TagPage(props: Props) {
                 Posts tagged <code>{props.tag}</code>
             </h1>
             <ul>
-                {props.posts.map(post => (
+                {props.links.map(link => (
                     <li>
-                        <Link href={`/posts/${post.filename}`}>
-                            <a>{post.frontMatter.title}</a>
+                        <Link href={link.url}>
+                            <a>{link.title}</a>
                         </Link>
                     </li>
                 ))}

--- a/posts/how-to-lorem-ipsum.md
+++ b/posts/how-to-lorem-ipsum.md
@@ -1,6 +1,7 @@
 ---
 title: How To Lorem Ipsum
 tags: [tutorial, installation]
+author: Morgan Lorem
 ---
 
 ## Introduction

--- a/posts/lorem-ipsum-dolor.md
+++ b/posts/lorem-ipsum-dolor.md
@@ -1,6 +1,7 @@
 ---
 title: Lorem Ipsum Dolor Sit Amet
 tags: [tutorial, search]
+author: Jordan Ipsum
 ---
 
 ## Introduction

--- a/util/loadAllPosts.ts
+++ b/util/loadAllPosts.ts
@@ -1,12 +1,21 @@
-import path from 'path'
 import listAllPosts from './listAllPosts'
 import loadMarkdownFile, { MarkdownFile } from './loadMarkdownFile'
 
-export default async function loadAllPosts(): Promise<MarkdownFile[]> {
+export default async function loadAllPosts(includeUnlisted: boolean = false): Promise<MarkdownFile[]> {
     const baseDirectory = 'posts'
     const posts = await listAllPosts(baseDirectory)
     const loadingPosts = posts.map(post => {
         return loadMarkdownFile(baseDirectory, post)
     })
-    return Promise.all(loadingPosts)
+    let loadedPosts = await Promise.all(loadingPosts)
+
+    // Exclude posts that are unlisted, unless includeUnlisted option is used.
+    if (!includeUnlisted) {
+        loadedPosts = loadedPosts.filter(post => !post.frontMatter.unlisted)
+    }
+
+    // Exclude posts that are not published.
+    loadedPosts = loadedPosts.filter(post => post.frontMatter.published)
+
+    return loadedPosts
 }

--- a/util/loadMarkdownFile.ts
+++ b/util/loadMarkdownFile.ts
@@ -5,6 +5,9 @@ import path from 'path'
 export interface FrontMatter {
     title: string
     tags: string[]
+    published: boolean
+    unlisted: boolean
+    author?: string
 }
 
 export interface MarkdownFile {
@@ -52,6 +55,9 @@ function normalizeFrontMatter(rawFrontMatter: ReturnType<typeof greyMatter>['dat
     return {
         title: rawFrontMatter.title ?? 'Untitled',
         tags: normalizeTags(rawFrontMatter.tags).map(tag => tag.toLocaleLowerCase()),
+        published: rawFrontMatter.published ?? true,
+        unlisted: rawFrontMatter.unlisted ?? false,
+        author: rawFrontMatter.author,
     }
 }
 


### PR DESCRIPTION
### Published

Set published to `false` to keep a post private. Default value is true (all posts are published by default).

```yaml
published: false
```
### Unlisted

Set unlisted to `true` to prevent a post from showing up in any list or index page. If the post is unlisted but it's published, then it will only be accessible by direct URL. Default is false.

```yaml
unlisted: true
```

### Author

Name of the post author as a string

```yaml
author: Lorem Ipsum
```