### PR TITLE
Add auto-generated table of contents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,8 @@
         "next-mdx-remote": "^2.1.4",
         "react": "17.0.2",
         "react-dom": "17.0.2",
+        "rehype-slug": "^4.0.1",
+        "remark-toc": "^7.2.0",
         "url-loader": "^4.1.1"
       },
       "devDependencies": {
@@ -3668,6 +3670,19 @@
         "stream-parser": "^0.3.1"
       }
     },
+    "node_modules/github-slugger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.3.0.tgz",
+      "integrity": "sha512-gwJScWVNhFYSRDvURk/8yhcFBee6aFjye2a7Lhb2bUyRulpIoek9p0I9Kt7PT67d/nUlZbFu8L9RLiA0woQN8Q==",
+      "dependencies": {
+        "emoji-regex": ">=6.0.0 <=6.1.1"
+      }
+    },
+    "node_modules/github-slugger/node_modules/emoji-regex": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.1.tgz",
+      "integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4="
+    },
     "node_modules/glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -3844,6 +3859,24 @@
         "web-namespaces": "^1.0.0"
       }
     },
+    "node_modules/hast-util-has-property": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-1.0.4.tgz",
+      "integrity": "sha512-ghHup2voGfgFoHMGnaLHOjbYFACKrRh9KFttdCzMCbFoBMJXiNi2+XTrPP8+q6cDJM/RSqlCfVWrjp1H201rZg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-heading-rank": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-1.0.1.tgz",
+      "integrity": "sha512-P6Hq7RCky9syMevlrN90QWpqWDXCxwIVOfQR2rK6P4GpY4bqjKEuCzoWSRORZ7vz+VgRpLnXimh+mkwvVFjbyQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-is-element": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.1.0.tgz",
@@ -3909,6 +3942,15 @@
         "web-namespaces": "^1.0.0",
         "xtend": "^4.0.0",
         "zwitch": "^1.0.0"
+      }
+    },
+    "node_modules/hast-util-to-string": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-1.0.4.tgz",
+      "integrity": "sha512-eK0MxRX47AV2eZ+Lyr18DCpQgodvaS3fAQO2+b9Two9F5HEoRPhiUMNzoXArMJfZi2yieFzUBMRl3HNJ3Jus3w==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/hast-util-whitespace": {
@@ -4748,6 +4790,33 @@
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz",
       "integrity": "sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A==",
       "dev": true
+    },
+    "node_modules/mdast-util-toc": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-toc/-/mdast-util-toc-5.1.0.tgz",
+      "integrity": "sha512-csimbRIVkiqc+PpFeKDGQ/Ck2N4f9FYH3zzBMMJzcxoKL8m+cM0n94xXm0I9eaxHnKdY9n145SGTdyJC7i273g==",
+      "dependencies": {
+        "@types/mdast": "^3.0.3",
+        "@types/unist": "^2.0.3",
+        "extend": "^3.0.2",
+        "github-slugger": "^1.2.1",
+        "mdast-util-to-string": "^2.0.0",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-toc/node_modules/mdast-util-to-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+      "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/mdi-react": {
       "version": "7.5.0",
@@ -6005,6 +6074,22 @@
         "jsesc": "bin/jsesc"
       }
     },
+    "node_modules/rehype-slug": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-4.0.1.tgz",
+      "integrity": "sha512-KIlJALf9WfHFF21icwTd2yI2IP+RQRweaxH9ChVGQwRYy36+hiomG4ZSe0yQRyCt+D/vE39LbAcOI/h4O4GPhA==",
+      "dependencies": {
+        "github-slugger": "^1.1.1",
+        "hast-util-has-property": "^1.0.0",
+        "hast-util-heading-rank": "^1.0.0",
+        "hast-util-to-string": "^1.0.0",
+        "unist-util-visit": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/remark/-/remark-13.0.0.tgz",
@@ -6706,6 +6791,19 @@
       "dev": true,
       "dependencies": {
         "mdast-util-to-markdown": "^0.6.0"
+      }
+    },
+    "node_modules/remark-toc": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/remark-toc/-/remark-toc-7.2.0.tgz",
+      "integrity": "sha512-ppHepvpbg7j5kPFmU5rzDC4k2GTcPDvWcxXyr/7BZzO1cBSPk0stKtEJdsgAyw2WHKPGxadcHIZRjb2/sHxjkg==",
+      "dependencies": {
+        "@types/unist": "^2.0.3",
+        "mdast-util-toc": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark/node_modules/remark-parse": {
@@ -11142,6 +11240,21 @@
         "stream-parser": "^0.3.1"
       }
     },
+    "github-slugger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.3.0.tgz",
+      "integrity": "sha512-gwJScWVNhFYSRDvURk/8yhcFBee6aFjye2a7Lhb2bUyRulpIoek9p0I9Kt7PT67d/nUlZbFu8L9RLiA0woQN8Q==",
+      "requires": {
+        "emoji-regex": ">=6.0.0 <=6.1.1"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.1.tgz",
+          "integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4="
+        }
+      }
+    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -11287,6 +11400,16 @@
         "web-namespaces": "^1.0.0"
       }
     },
+    "hast-util-has-property": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-1.0.4.tgz",
+      "integrity": "sha512-ghHup2voGfgFoHMGnaLHOjbYFACKrRh9KFttdCzMCbFoBMJXiNi2+XTrPP8+q6cDJM/RSqlCfVWrjp1H201rZg=="
+    },
+    "hast-util-heading-rank": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-1.0.1.tgz",
+      "integrity": "sha512-P6Hq7RCky9syMevlrN90QWpqWDXCxwIVOfQR2rK6P4GpY4bqjKEuCzoWSRORZ7vz+VgRpLnXimh+mkwvVFjbyQ=="
+    },
     "hast-util-is-element": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.1.0.tgz",
@@ -11353,6 +11476,11 @@
         "xtend": "^4.0.0",
         "zwitch": "^1.0.0"
       }
+    },
+    "hast-util-to-string": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-1.0.4.tgz",
+      "integrity": "sha512-eK0MxRX47AV2eZ+Lyr18DCpQgodvaS3fAQO2+b9Two9F5HEoRPhiUMNzoXArMJfZi2yieFzUBMRl3HNJ3Jus3w=="
     },
     "hast-util-whitespace": {
       "version": "1.0.4",
@@ -12053,6 +12181,27 @@
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz",
       "integrity": "sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A==",
       "dev": true
+    },
+    "mdast-util-toc": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-toc/-/mdast-util-toc-5.1.0.tgz",
+      "integrity": "sha512-csimbRIVkiqc+PpFeKDGQ/Ck2N4f9FYH3zzBMMJzcxoKL8m+cM0n94xXm0I9eaxHnKdY9n145SGTdyJC7i273g==",
+      "requires": {
+        "@types/mdast": "^3.0.3",
+        "@types/unist": "^2.0.3",
+        "extend": "^3.0.2",
+        "github-slugger": "^1.2.1",
+        "mdast-util-to-string": "^2.0.0",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit": "^2.0.0"
+      },
+      "dependencies": {
+        "mdast-util-to-string": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+          "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w=="
+        }
+      }
     },
     "mdi-react": {
       "version": "7.5.0",
@@ -13138,6 +13287,18 @@
         }
       }
     },
+    "rehype-slug": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-4.0.1.tgz",
+      "integrity": "sha512-KIlJALf9WfHFF21icwTd2yI2IP+RQRweaxH9ChVGQwRYy36+hiomG4ZSe0yQRyCt+D/vE39LbAcOI/h4O4GPhA==",
+      "requires": {
+        "github-slugger": "^1.1.1",
+        "hast-util-has-property": "^1.0.0",
+        "hast-util-heading-rank": "^1.0.0",
+        "hast-util-to-string": "^1.0.0",
+        "unist-util-visit": "^2.0.0"
+      }
+    },
     "remark": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/remark/-/remark-13.0.0.tgz",
@@ -13849,6 +14010,15 @@
       "dev": true,
       "requires": {
         "mdast-util-to-markdown": "^0.6.0"
+      }
+    },
+    "remark-toc": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/remark-toc/-/remark-toc-7.2.0.tgz",
+      "integrity": "sha512-ppHepvpbg7j5kPFmU5rzDC4k2GTcPDvWcxXyr/7BZzO1cBSPk0stKtEJdsgAyw2WHKPGxadcHIZRjb2/sHxjkg==",
+      "requires": {
+        "@types/unist": "^2.0.3",
+        "mdast-util-toc": "^5.0.0"
       }
     },
     "repeat-string": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "next-mdx-remote": "^2.1.4",
     "react": "17.0.2",
     "react-dom": "17.0.2",
+    "rehype-slug": "^4.0.1",
+    "remark-toc": "^7.2.0",
     "url-loader": "^4.1.1"
   },
   "devDependencies": {

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -28,11 +28,9 @@ export default function Post(props: Props) {
 
             <div className="mb-5">
                 {props.tags.map(tag => (
-                    <>
-                        <Link key={tag} href={`/tags/${tag}`}>
-                            <a className="badge badge-primary mr-1">{startCase(tag)}</a>
-                        </Link>
-                    </>
+                    <Link key={tag} href={`/tags/${tag}`}>
+                        <a className="badge badge-primary mr-1">{startCase(tag)}</a>
+                    </Link>
                 ))}
             </div>
 

--- a/posts/lorem-ipsum-dolor.md
+++ b/posts/lorem-ipsum-dolor.md
@@ -4,6 +4,8 @@ tags: [tutorial, search]
 author: Jordan Ipsum
 ---
 
+## Table of Contents
+
 ## Introduction
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum iaculis erat ac lacus tristique, id faucibus arcu convallis. Curabitur rhoncus aliquam quam vitae iaculis. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Lorem ipsum dolor sit amet, consectetur adipiscing elit. In blandit quam tempor arcu aliquam mollis. In hac habitasse platea dictumst. Donec lobortis erat non elit blandit, sed consectetur nisi aliquam. Aliquam erat volutpat. Maecenas dapibus iaculis lectus, nec egestas diam elementum id. Phasellus volutpat libero purus, vulputate blandit nunc tincidunt ut.

--- a/util/renderMdxSource.ts
+++ b/util/renderMdxSource.ts
@@ -1,7 +1,15 @@
 import renderToString from 'next-mdx-remote/render-to-string'
 import { MdxRemote } from 'next-mdx-remote/types'
 import { MarkdownFile } from './loadMarkdownFile'
+import remarkToc from 'remark-toc'
+import rehypeSlug from 'rehype-slug'
 
 export default function renderMdxSource(markdownFile: MarkdownFile, components: MdxRemote.Components) {
-    return renderToString(markdownFile.body, { components })
+    return renderToString(markdownFile.body, {
+        components,
+        mdxOptions: {
+            remarkPlugins: [remarkToc],
+            rehypePlugins: [rehypeSlug],
+        },
+    })
 }


### PR DESCRIPTION
This inserts a table of contents automatically, if a markdown file contains a placeholder section titled "Table of contents"

Uses [remark-toc](https://github.com/remarkjs/remark-toc).

Also uses [rehype-slug](https://github.com/rehypejs/rehype-slug) to turn each heading of the document into an anchor that can be linked to.

In the future we could make the table of contents show up elsewhere, like a separate column next to the content.