### PR TITLE
Add a Sourcegraph search box component

### DIFF
--- a/components/SouregraphSearch.tsx
+++ b/components/SouregraphSearch.tsx
@@ -1,0 +1,29 @@
+import React, { useState } from 'react'
+
+interface Props {
+    query: string
+}
+
+export default function SourcegraphSearch(props: Props) {
+    const [query, setQuery] = useState(props.query)
+    return (
+        <div className="row my-4">
+            <div className="col-auto">
+                <img width="32" src="/sourcegraph-mark.svg" />
+            </div>
+            <div className="col-auto">
+                <input
+                    type="text"
+                    className="form-control"
+                    value={query}
+                    onChange={event => setQuery(event.target.value)}
+                />
+            </div>
+            <div className="col-auto">
+                <a className="btn btn-primary" href={`https://sourcegraph.com/search?q=${encodeURIComponent(query)}`}>
+                    Search on Sourcegraph
+                </a>
+            </div>
+        </div>
+    )
+}

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -10,8 +10,9 @@ import getQueryParam from '../../util/getQueryParam'
 import startCase from 'lodash/startCase'
 import Link from 'next/link'
 import loadAllPosts from '../../util/loadAllPosts'
+import SourcegraphSearch from '../../components/SouregraphSearch'
 
-const components = { Counter }
+const components = { Counter, SourcegraphSearch }
 interface Props {
     title: string
     author?: string

--- a/posts/lorem-ipsum-dolor.md
+++ b/posts/lorem-ipsum-dolor.md
@@ -8,6 +8,8 @@ author: Jordan Ipsum
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum iaculis erat ac lacus tristique, id faucibus arcu convallis. Curabitur rhoncus aliquam quam vitae iaculis. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Lorem ipsum dolor sit amet, consectetur adipiscing elit. In blandit quam tempor arcu aliquam mollis. In hac habitasse platea dictumst. Donec lobortis erat non elit blandit, sed consectetur nisi aliquam. Aliquam erat volutpat. Maecenas dapibus iaculis lectus, nec egestas diam elementum id. Phasellus volutpat libero purus, vulputate blandit nunc tincidunt ut.
 
+<SourcegraphSearch query="onChange lang:ts"/>
+
 ## Prerequisites
 
 Nam sodales metus ut risus interdum, eget placerat ligula eleifend. Nam lacinia a nisl ut suscipit. Morbi congue convallis venenatis. Integer orci massa, malesuada at venenatis quis, varius at ipsum. Duis mollis dui dui, eu interdum sem luctus vel. Nullam sollicitudin, metus et euismod semper, augue eros ultricies mauris, in rhoncus justo odio quis velit.


### PR DESCRIPTION
Add a search box "widget" (component) which can be pre-filled with a search query and takes you to Sourcegraph search.

It's an early proof of concept of the idea.

The purpose is to show Sourcegraph search examples which can be searched on Sourcegraph by  clicking "Search on Sourcegraph".

The example in the search box can also be edited by the reader before searching.