### PR TITLE
Add links to markdown headings

### DIFF
--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -10,20 +10,54 @@ import startCase from 'lodash/startCase'
 import Link from 'next/link'
 import loadAllPosts from '../../util/loadAllPosts'
 import SourcegraphSearch from '../../components/SourcegraphSearch'
+import LinkIcon from 'mdi-react/LinkIcon'
 
-const classForHeadingElements = 'mb-4 mt-5'
+type HeadingTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5'
+
+const classForHeadingElements = 'mb-4 mt-5 reveal-on-hover-parent'
 const markdownComponents = {
     img: createComponentWithClasses('img', 'my-5 w-100'),
-    h1: createComponentWithClasses('h1', classForHeadingElements),
-    h2: createComponentWithClasses('h2', classForHeadingElements),
-    h3: createComponentWithClasses('h3', classForHeadingElements),
-    h4: createComponentWithClasses('h4', classForHeadingElements),
-    h5: createComponentWithClasses('h5', classForHeadingElements),
+    h1: createLinkableHeading('h1'),
+    h2: createLinkableHeading('h2'),
+    h3: createLinkableHeading('h3'),
+    h4: createLinkableHeading('h4'),
+    h5: createLinkableHeading('h5'),
 } as const
 
+function mergeClassName(props: { className?: string }, addedClassName: string) {
+    const baseClass = props.className ?? ''
+    const className = `${baseClass} ${addedClassName}`.trim()
+    return (props = { ...props, className })
+}
+
+/**
+ * Create a component that merges the given class names. Accepts any intrinsic
+ * HTML element, so that it can be used for Markdown element replacement.
+ */
 function createComponentWithClasses<T extends keyof JSX.IntrinsicElements>(tag: T, className: string) {
     return function (props: JSX.IntrinsicElements[T]) {
-        return React.createElement(tag, { ...props, className: `${props.className ?? ''} ${className}` })
+        return React.createElement(tag, mergeClassName(props, className))
+    }
+}
+/**
+ * Create a heading component (h1, h2, h3, etc) that includes a link icon which
+ * is revealed on hover and which links to the heading, to allow sharing links
+ * that point to particular sections in the markdown. The link is the same as
+ * generated in the table of contents.
+ */
+function createLinkableHeading<T extends HeadingTag>(tag: T) {
+    return function (props: JSX.IntrinsicElements[T]) {
+        const children = (
+            <>
+                {props.children}
+                {props.id && (
+                    <a className="ms-2 reveal-on-hover-child" title="Link to this section" href={`#${props.id}`}>
+                        <LinkIcon />
+                    </a>
+                )}
+            </>
+        )
+        return React.createElement(tag, mergeClassName(props, classForHeadingElements), children)
     }
 }
 
@@ -52,7 +86,7 @@ export default function Post(props: Props) {
             </div>
 
             <div className="markdown-content">
-                <MDXRemote {...props.mdxSource} components={components}/>
+                <MDXRemote {...props.mdxSource} components={components} />
             </div>
         </PageLayout>
     )
@@ -75,7 +109,7 @@ export const getStaticProps: GetStaticProps<Props> = async context => {
 
     return {
         props: {
-            title: markdownFile.frontMatter.title ?? 'Untitled',
+            title: markdownFile.frontMatter.title,
             author: markdownFile.frontMatter.author ?? '',
             tags: markdownFile.frontMatter.tags,
             mdxSource,

--- a/styles/typography.scss
+++ b/styles/typography.scss
@@ -15,3 +15,11 @@ code {
     padding: 10px;
     border-radius:10px;
   }
+
+.reveal-on-hover-child {
+  visibility: hidden;
+}
+
+.reveal-on-hover-parent:hover .reveal-on-hover-child {
+  visibility: visible;
+}


### PR DESCRIPTION
Add the ability to link to a heading in a post, by clicking on the link icon next to the heading.

The link icon is revealed upon hovering.

The links are the same as the ones generated in the table of contents.