### PR TITLE
Change default description tag

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -8,7 +8,7 @@ import { GoogleTagManagerScriptTag, GoogleTagManagerNoscriptFrame } from './Goog
 import NavBar from './NavBar'
 
 const defaultMetaTags = {
-    description: 'Find and fix things across all of your code with Sourcegraph universal code search.',
+    description: 'Sourcegraph Learn is an educational hub to support all developers.',
     image: '/headers/sourcegraph-learn-header.png',
 } as const
 


### PR DESCRIPTION
This sets a new default value for the `description` meta tag (for social preview or for SEO results) which is used for the home page, and also as a fallback description for posts that don't have a description value.

I used the repo description, and I removed a colon to turn it into a sentence.