### PR TITLE
fix 404.tsx file link text and eslint error

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,25 +1,25 @@
 import SignDirectionIcon from 'mdi-react/SignDirectionIcon'
 import * as React from 'react'
+
 import Layout from '../components/Layout'
 
-class NotFoundPage extends React.Component<any, {}> {
-    public render(): JSX.Element {
-        return (
-            <Layout location={this.props.location} className="bg-white">
-                <div className="container center error-page text-dark">
-                    <div>
-                        <div >
-                            <SignDirectionIcon />
-                        </div>
-                    </div>
-                    <h1>404: Not Found</h1>
-                    <p className="text-center">The requested URL was not found. <br/> Return to{' '}
-                      <a href="https://learn.sourcegraph.com">Sourcegraph Learn</a>
-                    </p>
+export const NotFoundPage: React.FunctionComponent<{
+    location: { pathname: string }
+}> = props => (
+    <Layout location={props.location} className="bg-white">
+        <div className="container center error-page text-dark">
+            <div>
+                <div>
+                    <SignDirectionIcon />
                 </div>
-            </Layout>
-        )
-    }
-}
+            </div>
+            <h1>404: Not Found</h1>
+            <p className="text-center">
+                The requested URL was not found. <br /> Return to{' '}
+                <a href="https://learn.sourcegraph.com">Sourcegraph Learn</a>
+            </p>
+        </div>
+    </Layout>
+)
 
 export default NotFoundPage

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -13,8 +13,8 @@ class NotFoundPage extends React.Component<any, {}> {
                         </div>
                     </div>
                     <h1>404: Not Found</h1>
-                    <p className="text-center">The requested URL was not found. <br/> Return to
-                      <a href="https://learn.sourcegraph.com"> Sourcegraph Learn</a>
+                    <p className="text-center">The requested URL was not found. <br/> Return to{' '}
+                      <a href="https://learn.sourcegraph.com">Sourcegraph Learn</a>
                     </p>
                 </div>
             </Layout>


### PR DESCRIPTION
- fix eslint react/prefer-stateless-function error in 404.tsx
- fix 404 link text: The link underline had a space at the beginning, so it looked like `Return to _Sourcegraph Learn`.