### PR TITLE
remove unneeded "posts/" from URLs to posts

### DIFF
--- a/components/CollectionView.tsx
+++ b/components/CollectionView.tsx
@@ -30,7 +30,7 @@ const CollectionView: React.FunctionComponent<Props> = props => (
                     )
                 }
                 return (
-                    <Link href={`/posts/${post.slug}`} key={post.slug}>
+                    <Link href={`/${post.slug}`} key={post.slug}>
                         <a className="list-group-item list-group-item-action">{titleText}</a>
                     </Link>
                 )

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,6 @@
+// @ts-check
+
+/** @type {import("next/dist/next-server/server/config-shared").NextConfig} */
 module.exports = {
   pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'md', 'mdx'],
   future: {
@@ -7,4 +10,5 @@ module.exports = {
   env: {
     NEXT_PUBLIC_URL: process.env.DEPLOY_URL,
   },
+  redirects: async () => [{ source: '/posts/:slug', destination: '/:slug', permanent: true }]
 }

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -1,12 +1,12 @@
 import { GetStaticPaths, GetStaticProps } from 'next'
 
-import Article, { Props as ArticleProps } from '../../components/Article'
-import getQueryParameter from '../../util/getQueryParameters'
-import loadAllPosts from '../../util/loadAllPosts'
-import loadCollections from '../../util/loadCollections'
-import loadMarkdownFile from '../../util/loadMarkdownFile'
-import omitUndefinedFields from '../../util/omitUndefinedFields'
-import serializeMdxSource from '../../util/serializeMdxSource'
+import Article, { Props as ArticleProps } from '../components/Article'
+import getQueryParameter from '../util/getQueryParameters'
+import loadAllPosts from '../util/loadAllPosts'
+import loadCollections from '../util/loadCollections'
+import loadMarkdownFile from '../util/loadMarkdownFile'
+import omitUndefinedFields from '../util/omitUndefinedFields'
+import serializeMdxSource from '../util/serializeMdxSource'
 
 export default Article
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -18,7 +18,7 @@ export const getStaticProps: GetStaticProps<Props> = async () => {
 
     return {
         props: {
-            posts: posts.map(post => omitUndefinedFields({ ...post, url: `/posts/${post.slug}` })),
+            posts: posts.map(post => omitUndefinedFields({ ...post, url: `/${post.slug}` })),
         },
     }
 }

--- a/pages/posts/index.tsx
+++ b/pages/posts/index.tsx
@@ -19,7 +19,7 @@ export const getStaticProps: GetStaticProps<Props> = async () => {
     const posts = await loadAllPosts()
     const postLinks = posts.map(post => ({
         title: post.frontMatter.title,
-        url: `/posts/${post.slug}`,
+        url: `/${post.slug}`,
     }))
     const tags = collectTags(posts)
     const tagLinks = tags.map(tag => ({

--- a/pages/tags/[tag].tsx
+++ b/pages/tags/[tag].tsx
@@ -29,7 +29,7 @@ export const getStaticProps: GetStaticProps<Props> = async context => {
     return {
         props: {
             tag,
-            posts: filteredPosts.map(post => omitUndefinedFields({ ...post, url: `/posts/${post.slug}` })),
+            posts: filteredPosts.map(post => omitUndefinedFields({ ...post, url: `/${post.slug}` })),
         },
     }
 }


### PR DESCRIPTION
All of our URLs contain posts/, such as:

- https://learn.sourcegraph.com/posts/regular-expression-patterns
- https://learn.sourcegraph.com/posts/how-to-install-sourcegraph-with-docker

Since everything will be a "post", we can remove `posts/` from the URLs to make them shorter. (A good blog post explaining why in more detail: swyx.io/namespacing-sites.)

Also sets up redirects from the old `/posts/:slug` URLs to the new `/:slug` URLs.

closes #107