### PR TITLE
Update logo image in footer

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -155,10 +155,8 @@ const Footer: React.FunctionComponent<Props> = ({ minimal }) => (
                             </ul>
                         </div>
                         <div className="col-12 col-lg-3 mb-5 order-md-1">
-                            <a className="row footer__logo ml-1" href="https://about.sourcegraph.com">
-                                <span role="img" aria-label="Sourcegraph - Universal code search">
-                                    {' '}
-                                </span>
+                            <a href="https://about.sourcegraph.com">
+                                <img className="row footer__logo ml-1" src="/sourcegraph-logo.svg" alt="Sourcegraph - Universal code search" />
                             </a>
                             <ul className="nav footer__social mt-1">
                                 <li className="nav-item">

--- a/styles/Footer.scss
+++ b/styles/Footer.scss
@@ -16,9 +16,9 @@
         font-weight: bolder;
     }
     &__logo {
-        background: url(/sourcegraph-logo.svg) no-repeat;
-        background-size: 200px;
         height: 40px;
+        margin-left: 0.1rem;
+        width: 200px;
     }
     &__social,
     &__postscript {


### PR DESCRIPTION
Resolves [Update logo image in footer](https://app.asana.com/0/1200198213175654/1200573416572567/f) ticket in Asana by updating the styles in the footer styles sheet and using an `img` with `alt` in place of the existing `span`.

![Screen Shot 2021-07-20 at 9 04 17 AM](https://user-images.githubusercontent.com/43454804/126329131-752eb16d-b27e-4fee-a01e-d7206d980810.png)
![Screen Shot 2021-07-20 at 9 04 34 AM](https://user-images.githubusercontent.com/43454804/126329154-101e33ac-40e9-444c-90c6-23233a186b1b.png)

Noticed there was a `margin-left` being set elsewhere on `about`, so added something that seemed reasonable to this PR:

On `about`:

![Screen Shot 2021-07-20 at 9 04 57 AM](https://user-images.githubusercontent.com/43454804/126329274-a3607c49-1ed4-4e4b-9c27-5c4aac10f08f.png)
