### PR TITLE
Quick ToC update to header styles

### DIFF
--- a/styles/typography.scss
+++ b/styles/typography.scss
@@ -31,7 +31,7 @@ code {
   }
 
   .header {
-    padding: 48px 0 0 32px;
+    padding: 48px 0 10px 32px;
   }
 
   ul {

--- a/styles/typography.scss
+++ b/styles/typography.scss
@@ -31,7 +31,7 @@ code {
   }
 
   .header {
-    margin-top: 30px;
+    padding: 48px 0 0 32px;
   }
 
   ul {


### PR DESCRIPTION
Looks like I didn't push the commit to align the header properly on the old branch, so here 'tis.

Should look like this:

![Screen Shot 2021-07-21 at 9 19 08 AM](https://user-images.githubusercontent.com/43454804/126559800-0ffcc9f2-8112-47f9-8d71-c4cdcf6f3a07.png)
