### PR TITLE
Add og:type meta property

### DIFF
--- a/components/Article.tsx
+++ b/components/Article.tsx
@@ -37,6 +37,7 @@ const Article: React.FunctionComponent<Props> = props => {
     const metaTags: MetaTags = {
         image: props.socialImage ?? props.image,
         description: props.description,
+        type: 'article',
     }
 
     // Special behavior on a video page (which is a page with the "video" tag):
@@ -68,7 +69,9 @@ const Article: React.FunctionComponent<Props> = props => {
             leftColumn={tocFragment}
         >
             {/* Header image */}
-            {props.image && showHeaderImage && <img src={props.image} className="w-100 mb-5" alt={props.imageAlt ? props.imageAlt : ''} />}
+            {props.image && showHeaderImage && (
+                <img src={props.image} className="w-100 mb-5" alt={props.imageAlt ? props.imageAlt : ''} />
+            )}
 
             {/* Title and author */}
             <h1>{props.title}</h1>

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -17,6 +17,7 @@ const defaultMetaTags = {
 export interface MetaTags {
     image?: string | null
     description?: string | null
+    type?: string
 }
 
 export interface Props {
@@ -41,6 +42,8 @@ const Layout: React.FunctionComponent<Props> = props => {
         documentTitle = `${documentTitle} - ${SITE_TITLE}`
     }
 
+    const metaType = props.metaTags?.type ?? 'website'
+
     // If the image is relative, prefix it with the public URL, because meta image tags expect an absolute URL.
     const metaDescription = props.metaTags?.description ?? defaultMetaTags.description
     let metaImage = props.metaTags?.image ?? defaultMetaTags.image
@@ -64,6 +67,7 @@ const Layout: React.FunctionComponent<Props> = props => {
                 {/* Prism theme for syntax highlighting */}
                 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.4.1/themes/prism.min.css" />
 
+                <meta property="og:type" content={metaType} />
                 <meta property="og:title" content={documentTitle} />
                 <meta property="og:image" content={metaImage} />
                 <meta name="description" content={metaDescription} />


### PR DESCRIPTION
### What should this PR do?

Add the `og:type` meta tag, which has a value of `website` for the index page, or `article` for article pages.

### Why are we making this change?

To fix the fact that `og:type` is expected as an Open Graph property, according to the [Facebook open graph validator](https://developers.facebook.com/tools/debug), and also other social previews may use the property (like Twitter).

### What are the acceptance criteria? 

When checking the site with [Facebook's Open Graph validator](https://developers.facebook.com/tools/debug), the message that says:

>The following required properties are missing: og:url, og:type, fb:app_id`

...should no longer include `og:type` as a missing property.

Also, if Twitter Cards start working by adding this change, that would be a good bonus outcome.

### How should this PR be tested?

- Put the PR deploy preview URL into the open graph validator
- Check the "Missing properties" section for the absence of `og:type`
- Check if any other error messages are showing up about `og:type`
- Check the [Twitter card validator](https://cards-dev.twitter.com/validator) to find out if this makes it render cards now.

## Pull request process

**Reviewers**:

1. Test functionality using the criteria above.
2. Offer tips for efficiency, feedback on best practices, and possible alternative approaches and things that may not have been considered.
3. For shorter, "quick" PRs, use your best judgement on #​2.
4. Use a collaborative approach and provide resources and/or context where appropriate.
5. Provide screenshots/grabs where appropriate to show findings during review.

**Reviewees**:

1. Prefer incremental and appropriately-scoped changes.
2. Leave a comment on things you want explicit feedback on.
3. Respond clearly to comments and questions.
