### PR TITLE
Add flag to show or hide table of contents

### DIFF
--- a/components/templates/Article.tsx
+++ b/components/templates/Article.tsx
@@ -28,6 +28,7 @@ export interface Props {
     collection?: RecordCollection | null
     slug: string
     alternateTitle?: string | null
+    showToc?: boolean
 }
 
 const components = { SourcegraphSearch, EmbeddedYoutubeVideo, GifLikeVideo, RegexIcon, CollectionView }
@@ -47,7 +48,7 @@ const Article: React.FunctionComponent<Props> = props => {
     const showHeaderImage = !props.tags.includes('video')
 
     let tocFragment
-    if (props.toc) {
+    if (props.toc && props.showToc) {
         tocFragment = unified().use(rehypeReact, { createElement: React.createElement }).stringify(props.toc)
         tocFragment = (
             <>

--- a/interfaces/FrontMatter.ts
+++ b/interfaces/FrontMatter.ts
@@ -26,6 +26,14 @@ export default interface FrontMatter {
     /** Image URL used for social image tag (og:image). If not present, the
      * social image defaults to the `image` field. */
     socialImage?: string | null
+    /**
+     * Flag to determine if table of contents should be shown for an article or not
+     * If present and its value true, table of contents should be shown
+     * If present and its value is false, TOC should not be shown
+     * If absent, TOC should be shown
+     * Hence by default it is visible except it is set to false
+     */
+    showToc?: boolean
 
     /** Content type */
     type: string

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -27,6 +27,7 @@ export const getStaticProps: GetStaticProps<ArticleProps> = async context => {
     const { recordCollections } = collections
     const parentCollection = recordCollections.find(collection => !!collection.members.find(member => member.slug === slug))
     const recordAuthor = markdownFile.frontMatter.author ? slugToTitleCase(markdownFile.frontMatter.author) : null
+    const showToc = markdownFile.frontMatter.showToc ?? true
     return {
         props: omitUndefinedFields({
             title: markdownFile.frontMatter.title,
@@ -38,6 +39,7 @@ export const getStaticProps: GetStaticProps<ArticleProps> = async context => {
             socialImage: markdownFile.frontMatter.socialImage,
             description: markdownFile.frontMatter.description,
             toc,
+            showToc,
             mdxSource: serializeResult,
             collection: parentCollection ?? null,
             slug,

--- a/pages/guides/[slug].tsx
+++ b/pages/guides/[slug].tsx
@@ -23,6 +23,7 @@ export const getStaticProps: GetStaticProps<ArticleProps> = async context => {
     const markdownFile = await loadMarkdownFile(baseDirectory, `${slug}.md`)
     const { serializeResult, toc } = await serializeMdxSource(markdownFile)
     const recordAuthor = markdownFile.frontMatter.author ? slugToTitleCase(markdownFile.frontMatter.author) : ''
+    const showToc = markdownFile.frontMatter.showToc ?? true
     return {
         props: omitUndefinedFields({
             title: markdownFile.frontMatter.title,
@@ -33,6 +34,7 @@ export const getStaticProps: GetStaticProps<ArticleProps> = async context => {
             socialImage: markdownFile.frontMatter.socialImage,
             description: markdownFile.frontMatter.description,
             toc,
+            showToc,
             mdxSource: serializeResult,
             slug,
         }),

--- a/posts/three-ways-to-search-video.md
+++ b/posts/three-ways-to-search-video.md
@@ -5,6 +5,7 @@ author: marek-zaluski
 image: https://i3.ytimg.com/vi/XLfE2YuRwvw/maxresdefault.jpg
 imageAlt: Marek Zaluski demos searching with Sourcegraph.
 type: posts
+showToc: false
 ---
 
 <EmbeddedYoutubeVideo id="XLfE2YuRwvw" />

--- a/util/validators.ts
+++ b/util/validators.ts
@@ -48,6 +48,7 @@ export function normalizeFrontMatter(rawFrontMatter: ReturnType<typeof greyMatte
         imageAlt: rawFrontMatter.imageAlt ? normalizeString(rawFrontMatter.imageAlt) : null,
         socialImage: rawFrontMatter.socialImage ? normalizeString(rawFrontMatter.socialImage) : null,
         description: rawFrontMatter.description ? normalizeString(rawFrontMatter.description) : null,
+        showToc: isBoolean(rawFrontMatter.showToc) ? rawFrontMatter.showToc : true,
         type: normalizeString(rawFrontMatter.type)
     }
 }


### PR DESCRIPTION
## Type of change
<!-- Please be sure to add the appropriate label to your PR. -->
Feature

### What should this PR do?
<!-- Does this PR resolve an Asana or Jira issue? Please include a link to the ticket. -->
Adds a flag to display or hide table of content
[DEVED-3](https://sourcegraph.atlassian.net/browse/DEVED-3?atlOrigin=eyJpIjoiMDk4NDFkMWU5MjA3NDQ5YjhlZmIzZjU1MDRjOGJhOGIiLCJwIjoiaiJ9)

### Why are we making this change?
<!-- What larger problem does this PR address? -->

We want to be able to hide or show table of content at will

### What are the acceptance criteria? 
<!-- What should be happening for this PR to be accepted? Please list criteria. -->
<!-- Do any stakeholders need to be tagged in this review? If so, please add them. -->
When a user sets the showToc flag on a resource, the Table of content should be shown or hidden, depending on the boolean value of the flag


### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->
- Pull and checkout to this branch
- Set the `showToc` flag on any resource
- Open the resource on the browser and see table of content hidden or show, depending on the value you set

## Screenshots
<img width="1446" alt="Screenshot 2021-07-30 at 19 07 31" src="https://user-images.githubusercontent.com/13929923/127782895-2943648f-576d-4fa4-af23-e471e4f74f39.png">

## Pull request process

**Reviewers**:

1. Test functionality using the criteria above.
2. Offer tips for efficiency, feedback on best practices, and possible alternative approaches and things that may not have been considered.
3. For shorter, "quick" PRs, use your best judgement on #​2.
4. Use a collaborative approach and provide resources and/or context where appropriate.
5. Provide screenshots/grabs where appropriate to show findings during review.

**Reviewees**:

1. Prefer incremental and appropriately-scoped changes.
2. Leave a comment on things you want explicit feedback on.
3. Respond clearly to comments and questions.
