### PR TITLE
Update nested header styles on ToC

### DIFF
--- a/components/atoms/TocWrapper/TocWrapperStyles.ts
+++ b/components/atoms/TocWrapper/TocWrapperStyles.ts
@@ -40,7 +40,5 @@ export const StyledHeaderTocItem = styled.li`
     padding: .8rem 0;
 `
 export const StyledTocItem = styled.li<Props>`
-    margin: ${props => props.anyHeaders
-        ? '.8rem'
-        : '.8rem 0'};
+    margin: .5rem 1.5rem;
 `

--- a/components/atoms/TocWrapper/index.tsx
+++ b/components/atoms/TocWrapper/index.tsx
@@ -1,3 +1,4 @@
+import convertHeaders from '@util/convertHeaders'
 import createRandomId from '@util/createRandomId'
 import sluggify from '@util/sluggify'
 import sluggifyHeaders from '@util/sluggifyHeaders'
@@ -16,27 +17,27 @@ interface Props {
 }
 
 const TocWrapper: FunctionComponent<Props> = props => {
-    const anyHeaders = props.tocContents.map(string => string.includes('Step')).includes(true)
+    const convertedHeaders = convertHeaders(props.tocContents)
 
     return (
         <StyledTocWrapper>
             <h5>Contents</h5>
                 <ul>
-                    {props.tocContents.map(item =>
-                        item.includes('Step')
-                        ? (
-                            <StyledHeaderTocItem key={createRandomId()}>
-                                <Link href={`/${props.slug}/#${sluggifyHeaders(sluggify(item))}`}>
-                                    <a>{item}</a>
-                                </Link>   
-                            </StyledHeaderTocItem>
-                        )
-                        : (
-                            <StyledTocItem anyHeaders={anyHeaders} key={createRandomId()}>
-                                <Link href={`/${props.slug}/#${sluggify(item)}`}>
-                                    <a>{item}</a>
+                    {convertedHeaders.map(header =>
+                        header.isNested
+                        ?  (
+                            <StyledTocItem key={createRandomId()}>
+                                <Link href={`/${props.slug}/#${sluggify(header.header)}`}>
+                                    <a>{header.header}</a>
                                 </Link>  
                             </StyledTocItem>
+                        )
+                        : (
+                            <StyledHeaderTocItem key={createRandomId()}>
+                                <Link href={`/${props.slug}/#${sluggifyHeaders(sluggify(header.header))}`}>
+                                    <a>{header.header}</a>
+                                </Link>   
+                            </StyledHeaderTocItem>
                         )
                     )}
                 </ul>

--- a/interfaces/TocHeader.ts
+++ b/interfaces/TocHeader.ts
@@ -1,0 +1,4 @@
+export default interface TocHeader {
+    isNested: boolean
+    header: string
+}

--- a/util/convertHeaders.ts
+++ b/util/convertHeaders.ts
@@ -1,0 +1,6 @@
+import TocHeader from '@interfaces/TocHeader'
+import returnNestedHeaders from '@util/returnNestedHeaders'
+
+const convertHeaders = (items: string[]): TocHeader[] => items.map(item => returnNestedHeaders(item))
+
+export default convertHeaders

--- a/util/returnHeaders.ts
+++ b/util/returnHeaders.ts
@@ -1,9 +1,9 @@
 const returnHeaders = (string: string): string[] | null => {
-    const regex = /^(### |## )(.*)\n/gm
-    const headerRegex = /^(### |## )(.*)/gi
+    const regex = /^(###|##)\s(.*)\n/gm
+    const headerRegex = /^(###|##)\s(.*)/gi
     const matchHeaders = string.match(regex)
     return matchHeaders
-        ? matchHeaders.map(match => match.trim().replace(headerRegex, '$2'))
+        ? matchHeaders.map(match => match.trim())
         : null
   }
   

--- a/util/returnNestedHeaders.ts
+++ b/util/returnNestedHeaders.ts
@@ -1,0 +1,22 @@
+import TocHeader from '@interfaces/TocHeader'
+
+const returnNestedHeaders = (header: string): TocHeader => {
+    const nestedHeaderRegex = /^(#{3})\s(.*)/gi
+    const headerRegex = /^(#{2})\s(.*)/gi
+    const headerMatch = header.match(nestedHeaderRegex)
+    if (headerMatch) {
+        const parsedHeader = header.replace(nestedHeaderRegex, '$2')
+        return {
+            isNested: true,
+            header: parsedHeader
+        }
+    } 
+    const parsedHeader = header.replace(headerRegex, '$2')
+
+    return {
+        isNested: false,
+        header: parsedHeader
+    }
+}
+
+export default returnNestedHeaders


### PR DESCRIPTION
### What should this PR do?
Resolves [DEVED-120](https://sourcegraph.atlassian.net/browse/DEVED-120) by updating how we handle styles on ToC. Tl;dr — all `h3` headers will be considered `nested`, meaning that they will display differently from non-nested headers.

### Why are we making this change?
- We want all nested headers to display as nested in a way that is clear and consistent across different ToC formats (procedural formats that have stated `Steps` and other formats that do not use that naming convention). For more context on how headers with em dashes are treated, see the plugin [`rehype-autolink-headings`](https://github.com/rehypejs/rehype-autolink-headings), which we currently use to add links to our headings in the body of our `posts`.

### What are the acceptance criteria? 
- All ToC look reasonable (screenshots below)

### How should this PR be tested?
- Check out the branch, and check that the ToC on different records look acceptable.

## Pull request process

**Reviewers**:

1. Test functionality using the criteria above.
2. Offer tips for efficiency, feedback on best practices, and possible alternative approaches and things that may not have been considered.
3. For shorter, "quick" PRs, use your best judgement on #​2.
4. Use a collaborative approach and provide resources and/or context where appropriate.
5. Provide screenshots/grabs where appropriate to show findings during review.

**Reviewees**:

1. Prefer incremental and appropriately-scoped changes.
2. Leave a comment on things you want explicit feedback on.
3. Respond clearly to comments and questions.
