### PR TITLE
Updates to Nav

### DIFF
--- a/components/NavBar/NavBarStyles.ts
+++ b/components/NavBar/NavBarStyles.ts
@@ -43,7 +43,7 @@ export const StyledNavBarLogoLink = styled.a`
 `
 export const SyledNavBarLogoImage = styled.img`
     height: auto;
-    vertical-align: -.3125rem;
+    vertical-align: -.3rem;
     width: 12.5rem;
 `
 

--- a/components/NavBar/index.tsx
+++ b/components/NavBar/index.tsx
@@ -20,7 +20,7 @@ const NavBar: FunctionComponent = () => {
     return (
         <StyledNavBarWrapper>
             <StyledNavBarContainer>
-                <StyledNavBarLogoLink href="https://learn.sourcegraph.com/">
+                <StyledNavBarLogoLink href="/">
                     <SyledNavBarLogoImage src="/sourcegraph-learn.svg" alt="Sourcegraph logo" width="150" height="25" />
                 </StyledNavBarLogoLink>
                 <StyledNavBarMobileToggle 
@@ -32,7 +32,6 @@ const NavBar: FunctionComponent = () => {
                 </StyledNavBarMobileToggle>
                 <StyledNavBarItemsWrapper expandOnMobile={expandOnMobile}>
                     <StyledNavBarItemsContainer>
-                        <StyledNavBarItemLink href="/">Sourcegraph Learn </StyledNavBarItemLink>
                         <StyledNavBarItemLink href="/tags/tutorial">Tutorials </StyledNavBarItemLink>
                         <StyledNavBarItemLink href="/tags/video">Videos </StyledNavBarItemLink>
                         <StyledNavBarItemLink href="https://docs.sourcegraph.com">Docs</StyledNavBarItemLink>


### PR DESCRIPTION
### What should this PR do?
Resolves [DEVED-135](https://sourcegraph.atlassian.net/browse/DEVED-135) and closes #114 by removing the current `Sign In` option from the main nav, along with the links referenced in #114. Also moves the nested `Learn` links to the top level of the nav, and uses the `Sourcegraph Learn` logo in place of the existing Sourcegraph logo.

### Why are we making this change?
- We do not currently offer a meaningful signed in experience for users, nor are there immediate plans to do so. We can therefore remove this button/option until a later point, when something like a meaningful signed in state for users exists.
- As #114  points out, our nav had headers that focused on more "commercial" things like pricing & customers. This PR moves the dedicated `Learn` genre headings to the top level of the nav, replacing those less pertinent headers.

### What are the acceptance criteria? 
- Reorganization decisions make sense.
- Styles look correct.
- Nav behaves as expected on desktop/mobile.

### How should this PR be tested?
- Check out the branch and take a gander at the nav on desktop/mobile, testing to ensure that its behavior matches current prod (with the exception of the nested `Learn` list, which has been removed).

## Pull request process

**Reviewers**:

1. Test functionality using the criteria above.
2. Offer tips for efficiency, feedback on best practices, and possible alternative approaches and things that may not have been considered.
3. For shorter, "quick" PRs, use your best judgement on #​2.
4. Use a collaborative approach and provide resources and/or context where appropriate.
5. Provide screenshots/grabs where appropriate to show findings during review.

**Reviewees**:

1. Prefer incremental and appropriately-scoped changes.
2. Leave a comment on things you want explicit feedback on.
3. Respond clearly to comments and questions.
