### PR TITLE
Add reposition hook for ToC

### DIFF
--- a/components/atoms/TocWrapper/TocWrapperStyles.ts
+++ b/components/atoms/TocWrapper/TocWrapperStyles.ts
@@ -2,6 +2,7 @@ import styled from 'styled-components'
 
 interface Props {
     isHighlighted?: boolean
+    setTop?: boolean
 }
 
 export const StyledTocTopWrapper = styled.div`
@@ -14,13 +15,16 @@ export const StyledTocWrapper = styled.div`
     left: 0;
 `
 
-export const StyledTocWrapperBody = styled.div`
+export const StyledTocWrapperBody = styled.div<Props>`
     display: flex;
     flex-direction: column;
     justify-content: left;
     max-width: 15.62rem;
     padding-right: 1.5rem;
     position: fixed;
+    top: ${props => props.setTop
+        ? '1.875rem'
+        : ''};
 
     @media screen and (max-width: 1024px) {
         display: none;

--- a/components/atoms/TocWrapper/index.tsx
+++ b/components/atoms/TocWrapper/index.tsx
@@ -1,4 +1,5 @@
 import useHighlightOnScroll from '@hooks/highlightOnScroll'
+import useRepositionOnScroll from '@hooks/repositionOnScroll'
 import convertHeaders from '@util/convertHeaders'
 import createRandomId from '@util/createRandomId'
 import sluggify from '@util/sluggify'
@@ -20,26 +21,36 @@ interface Props {
 }
 
 const TocWrapper: FunctionComponent<Props> = props => {
-    const [elements, setElements] = useState<Element[] | null>(null)
+    const [headers, setHeaders] = useState<Element[] | null>(null)
+    const [element, setElement] = useState<Element | null>(null)
     const convertedHeaders = convertHeaders(props.tocContents)
-    const highlightHook = useHighlightOnScroll(elements)
+    const highlightHook = useHighlightOnScroll(headers)
+    const repositionHook = useRepositionOnScroll(element)
     useEffect(() => {
         if (props.tocContents) {
-            const getElements = [].slice.call(document.querySelectorAll('h2, h3'))
-            setElements(getElements)
+            const getHeaders = [].slice.call(document.querySelectorAll('h2, h3'))
+            const getTagsContainer = document.querySelector('#tags')
+            setHeaders(getHeaders)
+            setElement(getTagsContainer)
         }
     }, [props.tocContents])
 
     useEffect(() => {
-        if (elements) {
-            highlightHook.setHeaders(elements)
+        if (headers) {
+            highlightHook.setHeaders(headers)
         }
-    }, [elements, highlightHook])
+    }, [headers, highlightHook])
+
+    useEffect(() => {
+        if (element) {
+            repositionHook.setElement(element)
+        }
+    }, [element, repositionHook])
 
     return (
         <StyledTocTopWrapper>
             <StyledTocWrapper>
-                <StyledTocWrapperBody>
+                <StyledTocWrapperBody setTop={repositionHook.reposition}>
                     <h5>Contents</h5>
                         <ul>
                             {convertedHeaders.map(header =>

--- a/components/templates/ArticleTemplate/index.tsx
+++ b/components/templates/ArticleTemplate/index.tsx
@@ -81,7 +81,7 @@ const ArticleTemplate: FunctionComponent<Props> = props => {
             {/* Tags list */}
             {props.tags.length > 0 ? 
                 (
-                    <StyledTagsWrapper>
+                    <StyledTagsWrapper id='tags'>
                         {props.tags.map(tag => (
                             <Button key={tag} href={`/tags/${tag}`} className='extra-small'>
                                 {tag}

--- a/hooks/highlightOnScroll.ts
+++ b/hooks/highlightOnScroll.ts
@@ -33,7 +33,7 @@ const useHighlightOnScroll = (initialHeaders: Element[] | null): HighlightHookOb
     return {
         activeHeader,
         headers,
-        setHeaders
+        setHeaders,
     }
 }
 

--- a/hooks/repositionOnScroll.ts
+++ b/hooks/repositionOnScroll.ts
@@ -1,0 +1,44 @@
+import PositionHookObject from '@interfaces/PositionHookObject'
+import { useEffect, useState } from 'react'
+
+const useRepositionOnScroll = (initialElement: Element | null): PositionHookObject => {
+    const [element, setElement] = useState(initialElement)
+    const [reposition, setReposition] = useState(false)
+
+    const repositionOnScroll = (entries:IntersectionObserverEntry[]): void => {
+       
+        entries.map(entry => {
+            if (!entry.isIntersecting) {
+                setReposition(true)
+            }
+            
+            if (entry.isIntersecting) {
+                setReposition(false)
+            }
+        })
+    }
+
+    useEffect(() => {
+        const options = {
+            threshold: [0.5]
+        }
+        const observer = new IntersectionObserver(repositionOnScroll, options)      
+        if (element) {
+            observer.observe(element)
+        }
+
+        return () => {
+            if (element) {
+                observer.unobserve(element)
+            }      
+        }
+    }, [element])
+
+    return {
+        element,
+        setElement,
+        reposition,
+    }
+}
+
+export default useRepositionOnScroll

--- a/interfaces/PositionHookObject.ts
+++ b/interfaces/PositionHookObject.ts
@@ -1,0 +1,5 @@
+export default interface PositionHookObject {
+    element: Element | null
+    reposition: boolean
+    setElement: (element: Element) => void
+}


### PR DESCRIPTION
### What should this PR do?
Resolves [DEVED-140](https://sourcegraph.atlassian.net/browse/DEVED-140) by adding a hook to reposition our ToC on scroll.

### Why are we making this change?
- We have some ToC elements that are on the longer side; this change will ensure that the contents for longer ToC elements remain fully visible as users scroll, even on smaller screens (before mobile breakpoints).

### What are the acceptance criteria? 
- Reposition hook works as expected, and the ToC top positioning changes on scroll (see screenshots below).

### How should this PR be tested?
- Check out the branch, and make sure that the ToC is repositioned on scroll.

## Pull request process

**Reviewers**:

1. Test functionality using the criteria above.
2. Offer tips for efficiency, feedback on best practices, and possible alternative approaches and things that may not have been considered.
3. For shorter, "quick" PRs, use your best judgement on #​2.
4. Use a collaborative approach and provide resources and/or context where appropriate.
5. Provide screenshots/grabs where appropriate to show findings during review.

**Reviewees**:

1. Prefer incremental and appropriately-scoped changes.
2. Leave a comment on things you want explicit feedback on.
3. Respond clearly to comments and questions.
