### PR TITLE
Updates to ToC positioning and homepage animations on mobile

### DIFF
--- a/components/Header/HeaderStyles.ts
+++ b/components/Header/HeaderStyles.ts
@@ -34,7 +34,7 @@ export const StyledHeaderImageContainer = styled.div`
 `
 export const StyledHeaderImage = styled.img`
     animation-name: ${logoAnimation};
-    animation-duration: .5s;
+    animation-duration: 1s;
     animation-iteration-count: 1;
     animation-timing-function: linear;
     margin-left: .625rem;
@@ -46,7 +46,8 @@ export const StyledHeaderText = styled.div`
     margin-left: 6.25rem;
 
     @media screen and (max-width: 768px) {
-        margin-left: 10rem;
+        font-size: 24px;
+        margin-left: 0;
     }
 `
 export const StyledHeaderTextContainer = styled.div`

--- a/components/NavBar/index.tsx
+++ b/components/NavBar/index.tsx
@@ -18,7 +18,7 @@ const NavBar: FunctionComponent = () => {
     const [ expandOnMobile, setExpandOnMobile ] = useState(false)
 
     return (
-        <StyledNavBarWrapper>
+        <StyledNavBarWrapper id='nav'>
             <StyledNavBarContainer>
                 <StyledNavBarLogoLink href="/">
                     <SyledNavBarLogoImage src="https://storage.googleapis.com/sourcegraph-assets/learn/logos/sourcegraph-learn.svg" alt="Sourcegraph logo" width="150" height="25" />

--- a/components/atoms/TocWrapper/index.tsx
+++ b/components/atoms/TocWrapper/index.tsx
@@ -29,9 +29,9 @@ const TocWrapper: FunctionComponent<Props> = props => {
     useEffect(() => {
         if (props.tocContents) {
             const getHeaders = [].slice.call(document.querySelectorAll('h2, h3'))
-            const getTagsContainer = document.querySelector('#tags')
+            const getNav = document.querySelector('#nav')
             setHeaders(getHeaders)
-            setElement(getTagsContainer)
+            setElement(getNav)
         }
     }, [props.tocContents])
 

--- a/components/templates/ArticleTemplate/index.tsx
+++ b/components/templates/ArticleTemplate/index.tsx
@@ -91,7 +91,7 @@ const ArticleTemplate: FunctionComponent<Props> = props => {
             {/* Tags list */}
             {props.tags.length > 0 ? 
                 (
-                    <StyledTagsWrapper id='tags'>
+                    <StyledTagsWrapper>
                         {props.tags.map(tag => (
                             <Button key={tag} href={`/tags/${sluggify(tag)}`} className='extra-small'>
                                 {tag}

--- a/hooks/repositionOnScroll.ts
+++ b/hooks/repositionOnScroll.ts
@@ -20,7 +20,7 @@ const useRepositionOnScroll = (initialElement: Element | null): PositionHookObje
 
     useEffect(() => {
         const options = {
-            threshold: [0.5]
+            threshold: [0]
         }
         const observer = new IntersectionObserver(repositionOnScroll, options)      
         if (element) {


### PR DESCRIPTION
### What should this PR do?
Resolves [DEVED-172](https://sourcegraph.atlassian.net/browse/DEVED-172) by changing the target element for the intersection observer reposition hook to be the main nav, rather than the tutorial tags container. Updates the threshold for the target as well.

Also slows the logo animation on the homepage, and breaks the homepage text into two lines on mobile.

### Why are we making this change?
- General style improvements help us improve user experience on the site.

### What are the acceptance criteria? 
- Reposition on scroll should now happen when the main nav is out of sight (the threshold is now `0`, so adjustment is based on the first pixel being visible/not visible).
- The logo animation on the homepage should now be slower, and more in line with the text reveal animation (they should both finish at the same time).
- The main header text on the homepage on mobile should now only be on two lines (rather than three).

### How should this PR be tested?
- Check out the branch, and test ToC behavior on tutorials.
- Check animation on homepage.
- Check homepage header text on mobile.

## Pull request process

**Reviewers**:

1. Test functionality using the criteria above.
2. Offer tips for efficiency, feedback on best practices, and possible alternative approaches and things that may not have been considered.
3. For shorter, "quick" PRs, use your best judgement on #​2.
4. Use a collaborative approach and provide resources and/or context where appropriate.
5. Provide screenshots/grabs where appropriate to show findings during review.

**Reviewees**:

1. Prefer incremental and appropriately-scoped changes.
2. Leave a comment on things you want explicit feedback on.
3. Respond clearly to comments and questions.
