### PR TITLE
Add SiteSearchBar atom for site searches

### DIFF
--- a/components/NavBar/index.tsx
+++ b/components/NavBar/index.tsx
@@ -1,4 +1,5 @@
 import Button from '@components/atoms/Button'
+import SiteSearch from '@components/atoms/SiteSearchBar'
 import MenuIcon from 'mdi-react/MenuIcon'
 import { FunctionComponent, useState } from 'react'
 
@@ -40,6 +41,7 @@ const NavBar: FunctionComponent = () => {
                             rel="noreferrer">
                             Docs
                         </StyledNavBarItemLink>
+                        <SiteSearch />
                     </StyledNavBarItemsContainer>
                     <div>                
                         <Button 

--- a/components/atoms/SiteSearchBar/SiteSearchBarStyles.ts
+++ b/components/atoms/SiteSearchBar/SiteSearchBarStyles.ts
@@ -1,0 +1,49 @@
+import styled from 'styled-components'
+
+export const StyledSearchForm = styled.form`
+    height: 2.25rem;
+    display: flex;
+    position: relative;
+    align-items: center;
+    border-radius: .375rem;
+    background: transparent;
+    border: 1px solid #e7e7e7;
+    color: #e7e7e7;
+    font-size: 1rem;
+    justify-content: space-evenly;
+    margin: 0 .625rem;
+
+    input {
+        display: inline-block;
+        width: 11.875rem;
+        height: 1rem;
+        padding: .438rem .688rem .438rem 1.75rem;
+        border: transparent;
+        font-weight: 400;
+        color: #3b454f;
+        font-size: 14px;
+        line-height: 1rem;
+        box-sizing: content-box;
+        background: transparent;
+        background-clip: padding-box;
+        border-radius: .3125rem;
+        box-shadow: none;
+        font-family: sans-serif;
+        opacity: .8;
+    }
+
+    svg {
+        margin: 0 .625rem;
+    }
+`
+
+export const StyledKeyboardInput = styled.kbd`
+    border: 1px solid #e7e7e7;
+    color: #e7e7e7;
+    background: transparent;
+    font-size: .875em;
+    padding: .125em .375em;
+    border-radius: .25rem;
+    width: 1.5625rem;
+    margin: .625rem;
+`

--- a/components/atoms/SiteSearchBar/index.tsx
+++ b/components/atoms/SiteSearchBar/index.tsx
@@ -1,0 +1,20 @@
+import SearchIcon from 'mdi-react/SearchIcon'
+import { FunctionComponent } from 'react'
+
+import { StyledSearchForm, StyledKeyboardInput } from './SiteSearchBarStyles'
+
+const SiteSearch: FunctionComponent = () => (
+    <StyledSearchForm>
+        <SearchIcon size='1.1em' />
+        <input
+            type='search'
+            placeholder='Search Sourcegraph Learn'
+            autoComplete='off'
+            autoCorrect='off'
+            autoCapitalize='off'
+            className='search-input st-default-search-input' />
+            <StyledKeyboardInput>&#8984;K</StyledKeyboardInput>
+    </StyledSearchForm>
+)
+
+export default SiteSearch

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,8 +1,24 @@
 import { AppProps } from 'next/app'
+import Script from 'next/script'
 import { FunctionComponent } from 'react'
 
 import '@styles/styles.scss'
 
-const App: FunctionComponent<AppProps> = ({ Component, pageProps }) => <Component {...pageProps} />
+const App: FunctionComponent<AppProps> = ({ Component, pageProps }) => (
+    <>
+        <Script strategy='lazyOnload'>
+        {`
+            (function(w,d,t,u,n,s,e){w['SwiftypeObject']=n;w[n]=w[n]||function(){
+                (w[n].q=w[n].q||[]).push(arguments);};s=d.createElement(t);
+                e=d.getElementsByTagName(t)[0];s.async=1;s.src=u;e.parentNode.insertBefore(s,e);
+                })(window,document,'script','//s.swiftypecdn.com/install/v2/st.js','_st');
+                
+                _st('install','kyHsdbiTxQgtRvcQc9rv','2.0.0');
+        `}
+        </Script>
+
+        <Component {...pageProps} />
+    </>
+)
 
 export default App


### PR DESCRIPTION
### What should this PR do?
Resolves [DEVED-174](https://sourcegraph.atlassian.net/browse/DEVED-174) by adding a `SiteSearchBar` atom to the application, to use in conjunction with Swiftype.

### Why are we making this change?
- We would like content on the `Learn` site to be easily discoverable.

### What are the acceptance criteria? 
TBD

### How should this PR be tested?
TBD

## Pull request process

**Reviewers**:

1. Test functionality using the criteria above.
2. Offer tips for efficiency, feedback on best practices, and possible alternative approaches and things that may not have been considered.
3. For shorter, "quick" PRs, use your best judgement on #​2.
4. Use a collaborative approach and provide resources and/or context where appropriate.
5. Provide screenshots/grabs where appropriate to show findings during review.

**Reviewees**:

1. Prefer incremental and appropriately-scoped changes.
2. Leave a comment on things you want explicit feedback on.
3. Respond clearly to comments and questions.
