### PR TITLE
Update author bio links

### DIFF
--- a/components/templates/ArticleTemplate/index.tsx
+++ b/components/templates/ArticleTemplate/index.tsx
@@ -11,7 +11,6 @@ import metaDataDefaults from '@lib/metaDataDefaults'
 import sluggify from '@util/sluggify'
 import slugToTitleCase from '@util/slugToTitleCase'
 import { MDXRemote, MDXRemoteSerializeResult } from 'next-mdx-remote'
-import Link from 'next/link'
 import { FunctionComponent } from 'react'
 
 import {


### PR DESCRIPTION
### What should this PR do?
Resolves [DEVED-191](https://sourcegraph.atlassian.net/browse/DEVED-191) by updating the author links in our tutorial templates to be `a` elements instead of `Link`s, to address Swiftype console warnings (see also #268). 

### Why are we making this change?
- Avoiding warnings is helpful and makes for clean code.

### What are the acceptance criteria? 
- Clicking through to an author page should not throw any warnings in the console.

### How should this PR be tested?
- Check out this branch, and ensure the above behavior holds true.

## Pull request process

**Reviewers**:

1. Test functionality using the criteria above.
2. Offer tips for efficiency, feedback on best practices, and possible alternative approaches and things that may not have been considered.
3. For shorter, "quick" PRs, use your best judgement on #​2.
4. Use a collaborative approach and provide resources and/or context where appropriate.
5. Provide screenshots/grabs where appropriate to show findings during review.

**Reviewees**:

1. Prefer incremental and appropriately-scoped changes.
2. Leave a comment on things you want explicit feedback on.
3. Respond clearly to comments and questions.
