### PR TITLE
Update tag title matching logic

### DIFF
--- a/util/filterRecordsWithTag.ts
+++ b/util/filterRecordsWithTag.ts
@@ -24,7 +24,7 @@ const filterRecordsWithTag = (records: MarkdownFile[], tag: string): FilteredRec
         const recordTagArray = Array.from(recordTagSet)
         
         return recordTagArray.some(item => {
-            if (checkMatch(item, tag)) {
+            if (checkMatch(item, tag) && item.length === tag.length) {
                 titleTag = item
             }
 


### PR DESCRIPTION
### What should this PR do?
Resolves [DEVED-229](https://sourcegraph.atlassian.net/browse/DEVED-229) by updating the matching logic used to determine header text on tag pages.

### Why are we making this change?
- In cases where a string was part of another string (e.g. Java/JavaScript), the title of the page was incorrect. Matched records were fine.

### What are the acceptance criteria? 
- All tag pages should display the correct title and records with that tag.

### How should this PR be tested?
- Check out the branch, and check the above, particularly the `Java` page.

## Pull request process

**Reviewers**:

1. Test functionality using the criteria above.
2. Offer tips for efficiency, feedback on best practices, and possible alternative approaches and things that may not have been considered.
3. For shorter, "quick" PRs, use your best judgement on #​2.
4. Use a collaborative approach and provide resources and/or context where appropriate.
5. Provide screenshots/grabs where appropriate to show findings during review.

**Reviewees**:

1. Prefer incremental and appropriately-scoped changes.
2. Leave a comment on things you want explicit feedback on.
3. Respond clearly to comments and questions.
