### PR TITLE
Pin eslint-plugin-unicorn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "eslint-plugin-jest-dom": "^3.9.2",
         "eslint-plugin-jsdoc": "^37.0.3",
         "eslint-plugin-react": "^7.26.1",
-        "eslint-plugin-unicorn": "37.0.1",
+        "eslint-plugin-unicorn": "21.0.0",
         "prettier": "^2.4.1",
         "sass": "^1.43.4",
         "typescript": "^4.4.4"
@@ -1123,63 +1123,6 @@
         "eslint-plugin-unicorn": "^21.0.0"
       }
     },
-    "node_modules/@sourcegraph/eslint-config/node_modules/@babel/code-frame": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-      "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/highlight": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@sourcegraph/eslint-config/node_modules/@babel/core": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.0.tgz",
-      "integrity": "sha512-mYZEvshBRHGsIAiyH5PzCFTCfbWfoYbO/jcSdXQSUQu1/pW0xDZAUP7KEc32heqWTAfAHhV9j1vH8Sav7l+JNQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.16.0",
-        "@babel/generator": "^7.16.0",
-        "@babel/helper-compilation-targets": "^7.16.0",
-        "@babel/helper-module-transforms": "^7.16.0",
-        "@babel/helpers": "^7.16.0",
-        "@babel/parser": "^7.16.0",
-        "@babel/template": "^7.16.0",
-        "@babel/traverse": "^7.16.0",
-        "@babel/types": "^7.16.0",
-        "convert-source-map": "^1.7.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.1.2",
-        "semver": "^6.3.0",
-        "source-map": "^0.5.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@sourcegraph/eslint-config/node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@sourcegraph/eslint-config/node_modules/ci-info": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-      "dev": true
-    },
     "node_modules/@sourcegraph/eslint-config/node_modules/comment-parser": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.7.6.tgz",
@@ -1225,79 +1168,6 @@
         "eslint": "^6.0.0 || ^7.0.0"
       }
     },
-    "node_modules/@sourcegraph/eslint-config/node_modules/eslint-plugin-unicorn": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-21.0.0.tgz",
-      "integrity": "sha512-S8v7+v4gZTQPj4pKKvexhgSUaLQSyItvxW2SVZDaX9Iu5IjlAmF2eni+L6w8a2aqshxgU8Lle4FIAVDtuejSKQ==",
-      "dev": true,
-      "dependencies": {
-        "ci-info": "^2.0.0",
-        "clean-regexp": "^1.0.0",
-        "eslint-ast-utils": "^1.1.0",
-        "eslint-template-visitor": "^2.0.0",
-        "eslint-utils": "^2.1.0",
-        "import-modules": "^2.0.0",
-        "lodash": "^4.17.15",
-        "pluralize": "^8.0.0",
-        "read-pkg-up": "^7.0.1",
-        "regexp-tree": "^0.1.21",
-        "reserved-words": "^0.1.2",
-        "safe-regex": "^2.1.1",
-        "semver": "^7.3.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
-      },
-      "peerDependencies": {
-        "eslint": ">=7.3.0"
-      }
-    },
-    "node_modules/@sourcegraph/eslint-config/node_modules/eslint-plugin-unicorn/node_modules/eslint-template-visitor": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/eslint-template-visitor/-/eslint-template-visitor-2.3.2.tgz",
-      "integrity": "sha512-3ydhqFpuV7x1M9EK52BPNj6V0Kwu0KKkcIAfpUhwHbR8ocRln/oUHgfxQupY8O1h4Qv/POHDumb/BwwNfxbtnA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.12.16",
-        "@babel/eslint-parser": "^7.12.16",
-        "eslint-visitor-keys": "^2.0.0",
-        "esquery": "^1.3.1",
-        "multimap": "^1.1.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=7.0.0"
-      }
-    },
-    "node_modules/@sourcegraph/eslint-config/node_modules/eslint-plugin-unicorn/node_modules/eslint-template-visitor/node_modules/@babel/eslint-parser": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.16.0.tgz",
-      "integrity": "sha512-c+AsYOHjI+FgCa+ifLd8sDXp4U4mjkfFgL9NdQWhuA731kAUJs0WdJIXET4A14EJAR9Jv9FFF/MzPWJfV9Oirw==",
-      "dev": true,
-      "dependencies": {
-        "eslint-scope": "^5.1.1",
-        "eslint-visitor-keys": "^2.1.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": ">=7.11.0",
-        "eslint": "^7.5.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@sourcegraph/eslint-config/node_modules/eslint-plugin-unicorn/node_modules/eslint-template-visitor/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@sourcegraph/eslint-config/node_modules/regextras": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/regextras/-/regextras-0.7.1.tgz",
@@ -1305,15 +1175,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.1.14"
-      }
-    },
-    "node_modules/@sourcegraph/eslint-config/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/@sourcegraph/prettierrc": {
@@ -2167,18 +2028,6 @@
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
-    "node_modules/builtin-modules": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
-      "integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/builtin-status-codes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
@@ -2328,9 +2177,9 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
-      "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
     },
     "node_modules/cipher-base": {
@@ -2770,9 +2619,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.887",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.887.tgz",
-      "integrity": "sha512-QQUumrEjFDKSVYVdaeBmFdyQGoaV+fCSMyWHvfx/u22bRHSTeBQYt6P4jMY+gFd4kgKB9nqk7RMtWkDB49OYPA=="
+      "version": "1.3.888",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.888.tgz",
+      "integrity": "sha512-5iD1zgyPpFER4kJ716VsA4MxQ6x405dxdFNCEK2mITL075VHO5ResjY0xzQUZguCww/KlBxCA6JmBA9sDt1PRw=="
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -3299,35 +3148,33 @@
       }
     },
     "node_modules/eslint-plugin-unicorn": {
-      "version": "37.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-37.0.1.tgz",
-      "integrity": "sha512-E1jq5u9ojnadisJcPi+hMXTGSiIzkIUMDvWsBudsCGXvKUB2aNSU2TcfyW2/jAS5A4ryBXfzxLykMxX1EdluSQ==",
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-21.0.0.tgz",
+      "integrity": "sha512-S8v7+v4gZTQPj4pKKvexhgSUaLQSyItvxW2SVZDaX9Iu5IjlAmF2eni+L6w8a2aqshxgU8Lle4FIAVDtuejSKQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "ci-info": "^3.2.0",
+        "ci-info": "^2.0.0",
         "clean-regexp": "^1.0.0",
-        "eslint-template-visitor": "^2.3.2",
-        "eslint-utils": "^3.0.0",
-        "esquery": "^1.4.0",
-        "indent-string": "4",
-        "is-builtin-module": "^3.1.0",
-        "lodash": "^4.17.21",
+        "eslint-ast-utils": "^1.1.0",
+        "eslint-template-visitor": "^2.0.0",
+        "eslint-utils": "^2.1.0",
+        "import-modules": "^2.0.0",
+        "lodash": "^4.17.15",
         "pluralize": "^8.0.0",
         "read-pkg-up": "^7.0.1",
-        "regexp-tree": "^0.1.23",
+        "regexp-tree": "^0.1.21",
+        "reserved-words": "^0.1.2",
         "safe-regex": "^2.1.1",
-        "semver": "^7.3.5",
-        "strip-indent": "^3.0.0"
+        "semver": "^7.3.2"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
       },
       "peerDependencies": {
-        "eslint": ">=7.32.0"
+        "eslint": ">=7.3.0"
       }
     },
     "node_modules/eslint-plugin-unicorn/node_modules/@babel/code-frame": {
@@ -3422,24 +3269,6 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/eslint-plugin-unicorn/node_modules/eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "dev": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "engines": {
-        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=5"
       }
     },
     "node_modules/eslint-plugin-unicorn/node_modules/source-map": {
@@ -4457,15 +4286,6 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -4599,18 +4419,6 @@
       ],
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/is-builtin-module": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.1.0.tgz",
-      "integrity": "sha512-OV7JjAgOTfAFJmHZLvpSTb4qi0nIILDV1gWPYDnDJUTNFM5aGlRAhk4QcT8i7TuAleeEV5Fdkqn3t4mS+Q11fg==",
-      "dev": true,
-      "dependencies": {
-        "builtin-modules": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/is-callable": {
@@ -5409,15 +5217,6 @@
       },
       "engines": {
         "node": ">=4.0.0"
-      }
-    },
-    "node_modules/min-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/minimalistic-assert": {
@@ -7753,18 +7552,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/strip-indent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-      "dev": true,
-      "dependencies": {
-        "min-indent": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -9451,52 +9238,6 @@
         "eslint-plugin-unicorn": "^21.0.0"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-          "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.16.0"
-          }
-        },
-        "@babel/core": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.0.tgz",
-          "integrity": "sha512-mYZEvshBRHGsIAiyH5PzCFTCfbWfoYbO/jcSdXQSUQu1/pW0xDZAUP7KEc32heqWTAfAHhV9j1vH8Sav7l+JNQ==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.16.0",
-            "@babel/generator": "^7.16.0",
-            "@babel/helper-compilation-targets": "^7.16.0",
-            "@babel/helper-module-transforms": "^7.16.0",
-            "@babel/helpers": "^7.16.0",
-            "@babel/parser": "^7.16.0",
-            "@babel/template": "^7.16.0",
-            "@babel/traverse": "^7.16.0",
-            "@babel/types": "^7.16.0",
-            "convert-source-map": "^1.7.0",
-            "debug": "^4.1.0",
-            "gensync": "^1.0.0-beta.2",
-            "json5": "^2.1.2",
-            "semver": "^6.3.0",
-            "source-map": "^0.5.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-              "dev": true
-            }
-          }
-        },
-        "ci-info": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-          "dev": true
-        },
         "comment-parser": {
           "version": "0.7.6",
           "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.7.6.tgz",
@@ -9527,71 +9268,10 @@
             "spdx-expression-parse": "^3.0.1"
           }
         },
-        "eslint-plugin-unicorn": {
-          "version": "21.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-21.0.0.tgz",
-          "integrity": "sha512-S8v7+v4gZTQPj4pKKvexhgSUaLQSyItvxW2SVZDaX9Iu5IjlAmF2eni+L6w8a2aqshxgU8Lle4FIAVDtuejSKQ==",
-          "dev": true,
-          "requires": {
-            "ci-info": "^2.0.0",
-            "clean-regexp": "^1.0.0",
-            "eslint-ast-utils": "^1.1.0",
-            "eslint-template-visitor": "^2.0.0",
-            "eslint-utils": "^2.1.0",
-            "import-modules": "^2.0.0",
-            "lodash": "^4.17.15",
-            "pluralize": "^8.0.0",
-            "read-pkg-up": "^7.0.1",
-            "regexp-tree": "^0.1.21",
-            "reserved-words": "^0.1.2",
-            "safe-regex": "^2.1.1",
-            "semver": "^7.3.2"
-          },
-          "dependencies": {
-            "eslint-template-visitor": {
-              "version": "2.3.2",
-              "resolved": "https://registry.npmjs.org/eslint-template-visitor/-/eslint-template-visitor-2.3.2.tgz",
-              "integrity": "sha512-3ydhqFpuV7x1M9EK52BPNj6V0Kwu0KKkcIAfpUhwHbR8ocRln/oUHgfxQupY8O1h4Qv/POHDumb/BwwNfxbtnA==",
-              "dev": true,
-              "requires": {
-                "@babel/core": "^7.12.16",
-                "@babel/eslint-parser": "^7.12.16",
-                "eslint-visitor-keys": "^2.0.0",
-                "esquery": "^1.3.1",
-                "multimap": "^1.1.0"
-              },
-              "dependencies": {
-                "@babel/eslint-parser": {
-                  "version": "7.16.0",
-                  "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.16.0.tgz",
-                  "integrity": "sha512-c+AsYOHjI+FgCa+ifLd8sDXp4U4mjkfFgL9NdQWhuA731kAUJs0WdJIXET4A14EJAR9Jv9FFF/MzPWJfV9Oirw==",
-                  "dev": true,
-                  "requires": {
-                    "eslint-scope": "^5.1.1",
-                    "eslint-visitor-keys": "^2.1.0",
-                    "semver": "^6.3.0"
-                  }
-                },
-                "semver": {
-                  "version": "6.3.0",
-                  "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                  "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                  "dev": true
-                }
-              }
-            }
-          }
-        },
         "regextras": {
           "version": "0.7.1",
           "resolved": "https://registry.npmjs.org/regextras/-/regextras-0.7.1.tgz",
           "integrity": "sha512-9YXf6xtW+qzQ+hcMQXx95MOvfqXFgsKDZodX3qZB0x2n5Z94ioetIITsBtvJbiOyxa/6s9AtyweBLCdPmPko/w==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
       }
@@ -10252,12 +9932,6 @@
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
-    "builtin-modules": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
-      "integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==",
-      "dev": true
-    },
     "builtin-status-codes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
@@ -10361,9 +10035,9 @@
       }
     },
     "ci-info": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
-      "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
     },
     "cipher-base": {
@@ -10721,9 +10395,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.887",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.887.tgz",
-      "integrity": "sha512-QQUumrEjFDKSVYVdaeBmFdyQGoaV+fCSMyWHvfx/u22bRHSTeBQYt6P4jMY+gFd4kgKB9nqk7RMtWkDB49OYPA=="
+      "version": "1.3.888",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.888.tgz",
+      "integrity": "sha512-5iD1zgyPpFER4kJ716VsA4MxQ6x405dxdFNCEK2mITL075VHO5ResjY0xzQUZguCww/KlBxCA6JmBA9sDt1PRw=="
     },
     "elliptic": {
       "version": "6.5.4",
@@ -11171,26 +10845,24 @@
       }
     },
     "eslint-plugin-unicorn": {
-      "version": "37.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-37.0.1.tgz",
-      "integrity": "sha512-E1jq5u9ojnadisJcPi+hMXTGSiIzkIUMDvWsBudsCGXvKUB2aNSU2TcfyW2/jAS5A4ryBXfzxLykMxX1EdluSQ==",
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-21.0.0.tgz",
+      "integrity": "sha512-S8v7+v4gZTQPj4pKKvexhgSUaLQSyItvxW2SVZDaX9Iu5IjlAmF2eni+L6w8a2aqshxgU8Lle4FIAVDtuejSKQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "ci-info": "^3.2.0",
+        "ci-info": "^2.0.0",
         "clean-regexp": "^1.0.0",
-        "eslint-template-visitor": "^2.3.2",
-        "eslint-utils": "^3.0.0",
-        "esquery": "^1.4.0",
-        "indent-string": "4",
-        "is-builtin-module": "^3.1.0",
-        "lodash": "^4.17.21",
+        "eslint-ast-utils": "^1.1.0",
+        "eslint-template-visitor": "^2.0.0",
+        "eslint-utils": "^2.1.0",
+        "import-modules": "^2.0.0",
+        "lodash": "^4.17.15",
         "pluralize": "^8.0.0",
         "read-pkg-up": "^7.0.1",
-        "regexp-tree": "^0.1.23",
+        "regexp-tree": "^0.1.21",
+        "reserved-words": "^0.1.2",
         "safe-regex": "^2.1.1",
-        "semver": "^7.3.5",
-        "strip-indent": "^3.0.0"
+        "semver": "^7.3.2"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -11263,15 +10935,6 @@
               "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
               "dev": true
             }
-          }
-        },
-        "eslint-utils": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-          "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-          "dev": true,
-          "requires": {
-            "eslint-visitor-keys": "^2.0.0"
           }
         },
         "source-map": {
@@ -12000,12 +11663,6 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
-    "indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -12094,15 +11751,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
       "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
-    },
-    "is-builtin-module": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.1.0.tgz",
-      "integrity": "sha512-OV7JjAgOTfAFJmHZLvpSTb4qi0nIILDV1gWPYDnDJUTNFM5aGlRAhk4QcT8i7TuAleeEV5Fdkqn3t4mS+Q11fg==",
-      "dev": true,
-      "requires": {
-        "builtin-modules": "^3.0.0"
-      }
     },
     "is-callable": {
       "version": "1.2.4",
@@ -12644,12 +12292,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
       "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
-      "dev": true
-    },
-    "min-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true
     },
     "minimalistic-assert": {
@@ -14387,15 +14029,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
       "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI="
-    },
-    "strip-indent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-      "dev": true,
-      "requires": {
-        "min-indent": "^1.0.0"
-      }
     },
     "strip-json-comments": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint-plugin-jsdoc": "^37.0.3",
     "eslint-plugin-react": "^7.26.1",
     "eslint-plugin-import": "^2.25.2",
-    "eslint-plugin-unicorn": "37.0.1",
+    "eslint-plugin-unicorn": "21.0.0",
     "eslint-plugin-jest-dom": "^3.9.2",
     "prettier": "^2.4.1",
     "sass": "^1.43.4",


### PR DESCRIPTION
### What should this PR do?
Resolves [DEVED-246](https://sourcegraph.atlassian.net/browse/DEVED-246) by pinning `eslint-plugin-unicorn` until the dependency [gets updated](https://github.com/sourcegraph/eslint-config/pull/227) on `sourcegraph/eslint-config`. Thanks to some recent changes in that package, we are required to have this plugin on our end, but linting with the latest version complains: `Configuration for rule "unicorn/prevent-abbreviations" is invalid`.

Part of the work on this ticket also involves disabling auto merges. We don't currently have the need for that capability, and can reinstate it if/when we do.

### Why are we making this change?
- We want linting to work.

### What are the acceptance criteria? 
- It should be possible to run `npm run lint` without error.
- Everything else should look/behave like it currently does on production.

### How should this PR be tested?
- Check out the branch, remove `node_modules`, and run `npm ci` to install deps.
- Run `npm run lint`.
- Ensure everything looks as it does on prod.

## Pull request process

**Reviewers**:

1. Test functionality using the criteria above.
2. Offer tips for efficiency, feedback on best practices, and possible alternative approaches and things that may not have been considered.
3. For shorter, "quick" PRs, use your best judgement on #​2.
4. Use a collaborative approach and provide resources and/or context where appropriate.
5. Provide screenshots/grabs where appropriate to show findings during review.

**Reviewees**:

1. Prefer incremental and appropriately-scoped changes.
2. Leave a comment on things you want explicit feedback on.
3. Respond clearly to comments and questions.
