### PR TITLE
Add hover styles on links in tutorial body

### DIFF
--- a/components/templates/ArticleTemplate/ArticleTemplateStyles.ts
+++ b/components/templates/ArticleTemplate/ArticleTemplateStyles.ts
@@ -75,6 +75,11 @@ export const StyledMarkdownWrapper = styled.div<Props>`
     a {
         color: var(--primary-link-color);
         text-decoration: none;
+
+        :hover {
+            color: ${props => props.isDark
+                ? '#5033e1'
+                : '#bfbfff'};
     }
     
     .reveal-on-hover-child {


### PR DESCRIPTION
### What should this PR do?
Resolves [DEVED-269](https://sourcegraph.atlassian.net/browse/DEVED-269) by adding hover colors for `<a>` elements on tutorials.

### Why are we making this change?
- Hover styles are nice for user experience, and we have them elsewhere.

### What are the acceptance criteria? 
- `<a>` elements on tutorials should have a color change applied on hover.
- The colors make sense in dark/ light mode.

### How should this PR be tested?
<!-- What should your reviewer do to test this PR? Please list steps. -->

## Pull request process

**Reviewers**:

1. Test functionality using the criteria above.
2. Offer tips for efficiency, feedback on best practices, and possible alternative approaches and things that may not have been considered.
3. For shorter, "quick" PRs, use your best judgement on #​2.
4. Use a collaborative approach and provide resources and/or context where appropriate.
5. Provide screenshots/grabs where appropriate to show findings during review.

**Reviewees**:

1. Prefer incremental and appropriately-scoped changes.
2. Leave a comment on things you want explicit feedback on.
3. Respond clearly to comments and questions.
