### PR TITLE
Add right padding for code elements in Highlighter

### DIFF
--- a/components/atoms/Highlighter/HighlighterStyles.ts
+++ b/components/atoms/Highlighter/HighlighterStyles.ts
@@ -9,6 +9,10 @@ export const StyledCodeBlock = styled.div<Props>`
     padding: ${props => props.isPrism
         ? ''
         : '1rem'};
+
+    span {
+        padding-right: .093rem;
+    }
 `
 export const StyledCodeWrapper = styled.pre<Props>`
     background-color: #e7e7e7 !important;
@@ -20,7 +24,9 @@ export const StyledCodeWrapper = styled.pre<Props>`
 export const StyledHighlighterMatch = styled.mark`
     background-color: #ffdb45 !important;
     color: #000 !important;
+    padding-right: .093rem;
 `
 export const StyledNonHighlighterMatch = styled.span`
     color: #000;
+    padding-right: .093rem;
 `


### PR DESCRIPTION
### What should this PR do?
Resolves [DEVED-281](https://sourcegraph.atlassian.net/browse/DEVED-281) by adding a small amount of padding to code elements in the `Highlighter` component, to prevent italicized tokens from being cut off.

### Why are we making this change?
- We want the code in code blocks to be legible.

### What are the acceptance criteria? 
- Padding looks reasonable in code blocks.
- Italicized text is not cut off (see, in particular, `how-to-stage-and-unstage-files-in-git`)

### How should this PR be tested?
- Check out the branch, and check various tutorials (those with author highlighting, those without; those with language syntax highlighting; `how-to-stage-and-unstage-files-in-git`) to make sure code blocks look decent.

## Pull request process

**Reviewers**:

1. Test functionality using the criteria above.
2. Offer tips for efficiency, feedback on best practices, and possible alternative approaches and things that may not have been considered.
3. For shorter, "quick" PRs, use your best judgement on #​2.
4. Use a collaborative approach and provide resources and/or context where appropriate.
5. Provide screenshots/grabs where appropriate to show findings during review.

**Reviewees**:

1. Prefer incremental and appropriately-scoped changes.
2. Leave a comment on things you want explicit feedback on.
3. Respond clearly to comments and questions.
