### PR TITLE
Fix height on homepage cards

### DIFF
--- a/components/atoms/ContentCard/ContentCardStyles.ts
+++ b/components/atoms/ContentCard/ContentCardStyles.ts
@@ -4,7 +4,17 @@ export const StyledCardBody = styled.div`
     color: var(--text-color);
     display: flex;
     flex-direction: column;
+    justify-content: center;
     padding: 1rem 1rem;
+    min-height: 8.75rem;
+
+    @media screen and (max-width: 768px) {
+        min-height: 12.5rem;
+    }
+
+    @media screen and (max-width: 576px) {
+        min-height: 8.75rem;
+    }
 `
 
 export const StyledCardTitle = styled.h5`
@@ -21,6 +31,6 @@ export const StyledCardTagList = styled.p`
     opacity: .8;
 `
 export const StyledCardImage = styled.img`
-    height: auto;
+    height: 100%;
     width: 100%;
 `


### PR DESCRIPTION
### What should this PR do?
Resolves [DEVED-282](https://sourcegraph.atlassian.net/browse/DEVED-282) by pinning the height of card images and text on the homepage.

### Why are we making this change?
- We want homepage cards to look reasonable.

### What are the acceptance criteria? 
- Homepage cards should look reasonable on desktop and mobile.

### How should this PR be tested?
- Check out branch and make sure above criteria are met.

## Pull request process

**Reviewers**:

1. Test functionality using the criteria above.
2. Offer tips for efficiency, feedback on best practices, and possible alternative approaches and things that may not have been considered.
3. For shorter, "quick" PRs, use your best judgement on #​2.
4. Use a collaborative approach and provide resources and/or context where appropriate.
5. Provide screenshots/grabs where appropriate to show findings during review.

**Reviewees**:

1. Prefer incremental and appropriately-scoped changes.
2. Leave a comment on things you want explicit feedback on.
3. Respond clearly to comments and questions.
