### PR TITLE
Update README with addition about backslashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,20 @@ When you have input with line spacing that you would like to preserve, use a tem
 />
 ```
 
+### Special Characters
+
+If you have a backslash `\` in your code input, be sure to escape it as follows:
+
+```
+use GuzzleHttp\\Client
+```
+
+This will output the desired single backslash:
+
+```
+use GuzzleHttp\Client
+```
+
 ### Output
 
 When displaying output, please use the `<Highlighter>` component. You do **not** need to specify a language when using this component, since it does not include language syntax highlighting. You can pass it a `matcher`, however, to draw attention to any code you would like to emphasize.


### PR DESCRIPTION
### What should this PR do?
Resolves [DEVED-278](https://sourcegraph.atlassian.net/browse/DEVED-278) by adding documentation about escaping backslashes to our top-level README.

### Why are we making this change?
- The `prism-react-renderer` includes regex logic that will not retain backslashes unless they escaped. Since this is happening one level "above" where we pass rendered tokens to our internal `Highlighter` component, the best we can do is play nicely with that logic. Escaping the `\` character will retain it in the code input block.

### What are the acceptance criteria? 
- The instructions in the README are clear and make sense.

### How should this PR be tested?
- Check out the README

## Pull request process

**Reviewers**:

1. Test functionality using the criteria above.
2. Offer tips for efficiency, feedback on best practices, and possible alternative approaches and things that may not have been considered.
3. For shorter, "quick" PRs, use your best judgement on #​2.
4. Use a collaborative approach and provide resources and/or context where appropriate.
5. Provide screenshots/grabs where appropriate to show findings during review.

**Reviewees**:

1. Prefer incremental and appropriately-scoped changes.
2. Leave a comment on things you want explicit feedback on.
3. Respond clearly to comments and questions.
