### PR TITLE
Adjust sizing on card links

### DIFF
--- a/components/atoms/CardLink/CardLinkStyles.ts
+++ b/components/atoms/CardLink/CardLinkStyles.ts
@@ -6,6 +6,8 @@ interface Props {
 
 export const StyledCardLink = styled.a<Props>`
     cursor: pointer;
+    height: 100%;
+    max-height: 377px;
     position: relative;
     display: flex;
     flex-direction: column;
@@ -32,5 +34,9 @@ export const StyledCardLink = styled.a<Props>`
     @media screen and (max-width: 576px) {
         margin: .75rem;
         width: unset;
+    }
+
+    @media screen and (max-width: 768px) {
+        max-height: 350px;
     }
 `

--- a/components/atoms/CardLink/CardLinkStyles.ts
+++ b/components/atoms/CardLink/CardLinkStyles.ts
@@ -37,6 +37,6 @@ export const StyledCardLink = styled.a<Props>`
     }
 
     @media screen and (max-width: 768px) {
-        max-height: 350px;
+        max-height: unset;
     }
 `

--- a/components/atoms/FeaturedContentBlock/FeaturedContentBlockStyles.ts
+++ b/components/atoms/FeaturedContentBlock/FeaturedContentBlockStyles.ts
@@ -45,7 +45,7 @@ export const StyledFeaturedContentItem = styled.li`
 `
 export const StyledHeaderText = styled.h5`
     font-size: 36px;
-    margin-bottom: 1rem;
+    margin-bottom: 1.5rem;
     justify-content: center;
     display: flex;
 `


### PR DESCRIPTION
### What should this PR do?
Resolves issue with CardLink sizing on older versions of Safari.

### Why are we making this change?
- We want our card elements to look as intended.

### What are the acceptance criteria? 
- Card links on the homepage and tag index pages should look reasonable.

### How should this PR be tested?
- Check out the deploy branch on older versions of Safari (< 15)

## Pull request process

**Reviewers**:

1. Test functionality using the criteria above.
2. Offer tips for efficiency, feedback on best practices, and possible alternative approaches and things that may not have been considered.
3. For shorter, "quick" PRs, use your best judgement on #​2.
4. Use a collaborative approach and provide resources and/or context where appropriate.
5. Provide screenshots/grabs where appropriate to show findings during review.

**Reviewees**:

1. Prefer incremental and appropriately-scoped changes.
2. Leave a comment on things you want explicit feedback on.
3. Respond clearly to comments and questions.
